### PR TITLE
Threejs: add *.obj file loader & correct spelling of OrbitControlsDirective

### DIFF
--- a/projects/three-wrapper/src/lib/objects/obj-loader.directive.ts
+++ b/projects/three-wrapper/src/lib/objects/obj-loader.directive.ts
@@ -1,0 +1,30 @@
+import { Directive, forwardRef } from '@angular/core';
+
+import { AbstractObject3D } from './abstract-object-3d';
+import { ModelLoaderDirective } from './model-loader.directive';
+
+import * as THREE from 'three';
+
+/**
+ * Directive for employing THREE.OBJLoader to load [Wavefront *.obj files][1].
+ *
+ * [1]: https://en.wikipedia.org/wiki/Wavefront_.obj_file
+ */
+@Directive({
+  selector: 'three-obj-loader',
+  providers: [{ provide: AbstractObject3D, useExisting: forwardRef(() => ObjLoaderDirective) }]
+})
+export class ObjLoaderDirective extends ModelLoaderDirective {
+  private loader = new THREE.OBJLoader();
+
+  protected async loadModelObject() {
+    return new Promise<THREE.Object3D>((resolve, reject) => {
+      this.loader.load(this.model, model => {
+          resolve(model);
+        },
+        undefined,
+        reject
+      );
+    });
+  }
+}

--- a/projects/three-wrapper/src/lib/three-wrapper.module.ts
+++ b/projects/three-wrapper/src/lib/three-wrapper.module.ts
@@ -3,6 +3,7 @@ import { RadiansToDegreePipe } from './pipes/radians-to-degree.pipe';
 import { DegreesToRadiansPipe } from './pipes/degrees-to-radians.pipe';
 import { PointLightDirective } from './objects/point-light.directive';
 import { ObjectLoaderDirective } from './objects/object-loader.directive';
+import { ObjLoaderDirective } from './objects/obj-loader.directive';
 import { GridHelperDirective } from './objects/grid-helper.directive';
 import { RendererComponent } from './renderer/renderer.component';
 import { PerspectiveCameraDirective } from './cameras/perspective-camera.directive';
@@ -21,6 +22,7 @@ import { AxesHelperDirective } from './objects/axes-helper.directive';
     AxesHelperDirective,
     GridHelperDirective,
     ObjectLoaderDirective,
+    ObjLoaderDirective,
     PointLightDirective
   ],
   exports: [
@@ -32,6 +34,7 @@ import { AxesHelperDirective } from './objects/axes-helper.directive';
     AxesHelperDirective,
     GridHelperDirective,
     ObjectLoaderDirective,
+    ObjLoaderDirective,
     PointLightDirective
   ]
 })

--- a/projects/three-wrapper/src/public_api.ts
+++ b/projects/three-wrapper/src/public_api.ts
@@ -15,5 +15,6 @@ export * from './lib/objects/scene.directive';
 export * from './lib/objects/model-loader.directive';
 export * from './lib/objects/grid-helper.directive';
 export * from './lib/objects/object-loader.directive';
+export * from './lib/objects/obj-loader.directive';
 export * from './lib/objects/point-light.directive';
 

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -21,7 +21,7 @@ Z rotation: <input type="range" min="-3.141" max="3.141" step="0.1" [(ngModel)]=
 Y translation: <input type="range" min="-50" max="50" step="1" [(ngModel)]="translationY"> {{ translationY }}
 
 <hr>
-<three-orbit-contols [rotateSpeed]=1 [zoomSpeed]=1.2 [listeningControlElement]=mainRenderer.renderPane>
+<three-orbit-controls [rotateSpeed]=1 [zoomSpeed]=1.2 [listeningControlElement]=mainRenderer.renderPane>
   <three-renderer #mainRenderer>
 
     <three-perspective-camera [fov]=60 [near]=1 [far]=1100 positionX=20 positionY=50 positionZ=50></three-perspective-camera>
@@ -52,4 +52,4 @@ Y translation: <input type="range" min="-50" max="50" step="1" [(ngModel)]="tran
 
     </three-scene>
   </three-renderer>
-</three-orbit-contols>
+</three-orbit-controls>

--- a/src/app/three-examples/controls/orbit-controls.directive.ts
+++ b/src/app/three-examples/controls/orbit-controls.directive.ts
@@ -15,7 +15,7 @@ import '../js/EnableThreeExamples';
 import 'three/examples/js/controls/OrbitControls';
 
 @Directive({
-  selector: 'three-orbit-contols'
+  selector: 'three-orbit-controls'
 })
 export class OrbitControlsDirective implements AfterViewInit, OnChanges, OnDestroy {
 


### PR DESCRIPTION
Actually, I find the naming of `THREE.ObjectLoader` and `THREE.ObjLoader` for two completely different file formats confusing. But since this repository shall only be a wrapper, we should keep the naming I think, so that Three.js developers are familiar with the terminology.